### PR TITLE
docs: add contributor onboarding and cross-platform quick start

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,16 @@ Please read the [Code of Conduct](CODE_OF_CONDUCT.md) before participating. For
 security issues, follow [SECURITY.md](SECURITY.md) instead of opening a public
 issue.
 
+## New here?
+
+- Run the disposable, cross-platform [`five-minute quick start`](docs/QUICK_START.md).
+- Choose an area and difficulty level in [`contributing paths`](docs/CONTRIBUTOR_PATHS.md).
+- Follow the public [`roadmap`](ROADMAP.md) and active [contributor-ready alpha tracker](https://github.com/moelomda/context-atlas/issues/8).
+
+You do not need to understand the whole evidence model before contributing. A
+narrow documentation, accessibility, fixture, error-message, or compatibility
+improvement is a valuable first pull request when its result can be verified.
+
 ## Before you start
 
 - Search existing issues before filing a new one.
@@ -62,7 +72,7 @@ For implementation work, comment on the issue with:
 
 1. the behavior you intend to change;
 2. the evidence or test that will prove it;
-3. any compatibility, privacy, or migration implications.
+3. any compatibility, privacy, security, or migration implications.
 
 An issue comment does not reserve work indefinitely. It helps contributors
 avoid duplicating effort and gives maintainers a chance to surface design

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,8 @@ Context Atlas is building a local-first, evidence-backed memory layer for softwa
 
 This public roadmap turns the detailed engineering plans under [`docs/`](docs/) into a shorter path that users and contributors can follow.
 
+**Start here:** run the [`five-minute quick start`](docs/QUICK_START.md), choose a track in [`contributing paths`](docs/CONTRIBUTOR_PATHS.md), and follow the active [`contributor-ready alpha tracker`](https://github.com/moelomda/context-atlas/issues/8).
+
 ## Current stage
 
 Context Atlas is a working experimental alpha. It already includes a TypeScript library, CLI, loopback dashboard, SQLite knowledge store, temporal evidence model, immutable audit ledger, bounded context packs, read-only MCP server, extension contracts, tests, cross-platform CI, CodeQL, dependency review, and a release workflow.
@@ -154,7 +156,7 @@ The following are not current priorities unless evidence changes the roadmap:
 
 ## How to contribute
 
-Read [`CONTRIBUTING.md`](CONTRIBUTING.md), run `npm ci` and `npm run check`, then choose or open a focused issue. In your issue comment, state the behavior you plan to change, the test or evidence that will prove it, and any compatibility, privacy, security, or migration impact.
+Run [`docs/QUICK_START.md`](docs/QUICK_START.md), choose a suitable track in [`docs/CONTRIBUTOR_PATHS.md`](docs/CONTRIBUTOR_PATHS.md), and read [`CONTRIBUTING.md`](CONTRIBUTING.md). Then choose or open a focused issue. In your issue comment, state the behavior you plan to change, the test or evidence that will prove it, and any compatibility, privacy, security, or migration impact.
 
 The detailed architecture, implementation, risk, and release plans remain available in:
 

--- a/docs/CONTRIBUTOR_PATHS.md
+++ b/docs/CONTRIBUTOR_PATHS.md
@@ -1,0 +1,338 @@
+# Contributing Paths
+
+Context Atlas welcomes contributors who care about developer tools, project knowledge, Git, TypeScript, SQLite, MCP, accessibility, privacy, testing, documentation, or open-source operations. You do not need to understand the whole system before making a useful contribution.
+
+This guide maps common contribution types to the relevant code, tests, and trust boundaries.
+
+## Start in 15 minutes
+
+1. Read the project summary and safety model in [`README.md`](../README.md).
+2. Run the disposable-repository workflow in [`QUICK_START.md`](QUICK_START.md).
+3. Read the contribution rules in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+4. Choose one open issue with a scope you can explain and test.
+5. Comment on the issue before starting significant implementation work.
+
+In the issue comment, state:
+
+```text
+Behavior I plan to change:
+Evidence or test that will prove it:
+Compatibility, privacy, security, or migration impact:
+Expected pull-request size:
+```
+
+A comment is coordination, not permanent ownership. Maintainers may suggest a smaller first change or identify an invariant that the issue description does not mention.
+
+## Choose a contribution track
+
+### 1. Documentation and onboarding
+
+Good for first-time contributors and people evaluating the product from a user's perspective.
+
+Typical work:
+
+- correct a command or platform-specific instruction;
+- improve examples and expected-output descriptions;
+- clarify errors, empty states, limits, or known limitations;
+- create a synthetic tutorial repository or walkthrough;
+- improve architecture diagrams without changing their meaning; or
+- verify a guide from a clean checkout and record the environment.
+
+Start with:
+
+- [`README.md`](../README.md)
+- [`QUICK_START.md`](QUICK_START.md)
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md)
+- [`ROADMAP.md`](../ROADMAP.md)
+- files under `docs/`
+
+Current entry point: [issue #3 — cross-platform five-minute quick start](https://github.com/moelomda/context-atlas/issues/3).
+
+### 2. Accessibility and dashboard experience
+
+Good for frontend developers, designers, accessibility testers, and contributors who can reproduce browser behavior carefully.
+
+Typical work:
+
+- keyboard and focus behavior;
+- screen-reader names and live-region behavior;
+- small-screen layouts;
+- reduced-motion behavior;
+- empty, loading, stale, conflicting, and failure states;
+- graph readability and bounded rendering; or
+- consistent explanations of authority, evidence, and freshness.
+
+Start with:
+
+- `src/web/public/index.html`
+- `src/web/public/app.js`
+- `src/web/public/styles.css`
+- `src/web/server.ts`
+- web-related tests under `tests/`
+
+Dashboard changes must preserve escaping, loopback-only serving, same-origin mutation controls, bounded requests, and the separation between human review and agent capabilities. Include screenshots or a short recording and describe keyboard checks in the pull request.
+
+### 3. Tests, fixtures, and public contracts
+
+Good for contributors who want a contained engineering task without redesigning core semantics.
+
+Typical work:
+
+- exact boundary tests;
+- platform-specific path and Git fixtures;
+- malformed-input and recovery tests;
+- API/MCP contract fixtures;
+- package-install smoke coverage;
+- deterministic synthetic-secret cases; or
+- compatibility tests for the minimum supported runtime.
+
+Start with:
+
+- `tests/`
+- `.github/workflows/ci.yml`
+- `.github/scripts/`
+- `src/core/contracts.ts`
+- `src/mcp/`
+
+Current entry points:
+
+- [issue #2 — unify external-import size contracts](https://github.com/moelomda/context-atlas/issues/2)
+- [issue #4 — test the exact minimum Node.js runtime](https://github.com/moelomda/context-atlas/issues/4)
+
+Strong tests prove public behavior and failure behavior with disposable data. Avoid tests that depend on a developer's home directory, global Git configuration, network access, wall-clock timing, or private repositories.
+
+### 4. Git ingestion and repository modeling
+
+Good for developers familiar with Git plumbing, filesystem behavior, parsing, and incremental indexing.
+
+Typical work:
+
+- NUL-safe Git command parsing;
+- rename, worktree, submodule, sparse-checkout, or object-format fixtures;
+- fewer Git subprocesses;
+- incremental/full equivalence;
+- safe path normalization and ignore behavior; or
+- bounded repository fingerprinting.
+
+Start with:
+
+- `src/core/git.ts`
+- `src/core/ingest.ts`
+- `src/core/ignore.ts`
+- `src/core/config.ts`
+- ingestion and Git tests under `tests/`
+
+Never introduce shell-string command construction for repository-controlled input. Keep argument-array process calls, explicit limits, canonical paths, and sensitive-path policy intact.
+
+### 5. Storage, integrity, and recovery
+
+Good for experienced contributors comfortable with SQLite, migrations, transactions, immutable audit records, crash behavior, and data compatibility.
+
+Typical work:
+
+- query pagination and indexes;
+- migration fixtures;
+- backup/restore qualification;
+- outbox and ledger recovery;
+- concurrent-access behavior;
+- corruption detection; or
+- structured operational diagnostics.
+
+Start with:
+
+- `src/core/database.ts`
+- `src/core/ledger.ts`
+- `src/core/portable.ts`
+- storage, ledger, migration, and recovery tests
+- [`ARCHITECTURE.md`](ARCHITECTURE.md)
+- [`RISK_REGISTER.md`](RISK_REGISTER.md)
+
+Changes in this track require explicit rollback or recovery evidence. Do not rewrite immutable history, silently repair corruption, or weaken durable-write settings merely to improve benchmark numbers.
+
+### 6. Context packs, search, and temporal knowledge
+
+Good for developers interested in relevance, deterministic selection, knowledge graphs, bitemporal state, explainability, and coding-agent context.
+
+Typical work:
+
+- selection and relevance fixtures;
+- bounded search and graph queries;
+- incremental size accounting;
+- tokenizer adapters;
+- evidence closure;
+- temporal assertion history; or
+- clearer exclusions, conflicts, and unknowns.
+
+Start with:
+
+- `src/core/context-pack.ts`
+- `src/core/query.ts`
+- `src/core/temporal.ts`
+- `src/core/claim-status.ts`
+- context-pack, query, and temporal tests
+
+A relevance improvement is incomplete if it hides omitted material or removes evidence, authority, freshness, conflict, or truncation metadata. Generated narrative remains non-authoritative until explicitly reviewed.
+
+### 7. MCP and extension ecosystem
+
+Good for developers familiar with MCP clients, schemas, adapters, plugins, and compatibility contracts.
+
+Typical work:
+
+- a second-client conformance fixture;
+- extension examples;
+- schema boundary tests;
+- installed-package MCP smoke tests;
+- clearer extension diagnostics; or
+- compatibility/deprecation documentation.
+
+Start with:
+
+- `src/mcp/`
+- `src/extensions/`
+- `plugin/context-atlas/`
+- [`EXTENSIONS.md`](EXTENSIONS.md)
+- MCP and extension tests
+
+MCP is intentionally read-only. Do not add synchronization, proposal creation, human review decisions, pack persistence, or retention application to the agent surface without an approved architecture change.
+
+### 8. Security and privacy
+
+Good for experienced security-minded contributors. Public issues must never contain real vulnerabilities, credentials, proprietary source, personal data, or real `.context-atlas` state.
+
+Typical non-sensitive public work:
+
+- synthetic secret-detector fixtures;
+- safe diagnostics;
+- permission and path-policy tests;
+- egress contract tests;
+- threat-model documentation; or
+- pluggable scanner interfaces that retain the built-in safe baseline.
+
+Start with:
+
+- [`SECURITY.md`](../SECURITY.md)
+- `src/core/security.ts`
+- `src/core/privacy.ts`
+- `src/core/egress.ts`
+- `src/web/server.ts`
+- security, privacy, and egress tests
+
+Report an actual vulnerability privately through the process in `SECURITY.md`. Do not open a public issue or proof-of-concept pull request for it.
+
+### 9. Performance and production qualification
+
+Good for contributors who can measure before optimizing and preserve correctness under load.
+
+Typical work:
+
+- synthetic benchmark generators;
+- versioned benchmark result schemas;
+- SQL-level filtering and pagination;
+- batched Git history extraction;
+- worker isolation;
+- memory and subprocess instrumentation; or
+- regression budgets.
+
+Start with [issue #6 — reproducible large-repository benchmark harness](https://github.com/moelomda/context-atlas/issues/6).
+
+Performance claims must identify the repository class, hardware, OS, Node version, Git version, commit SHA, warm/cold state, sample count, and measured percentile. A fast nine-entity fixture is useful regression evidence but not production-scale qualification.
+
+### 10. Release engineering and open-source operations
+
+Good for contributors interested in packaging, reproducibility, SBOMs, provenance, changelogs, triage, and sustainable project governance.
+
+Typical work:
+
+- clean-install verification;
+- release-note review;
+- checksum documentation;
+- package-boundary tests;
+- support and triage documentation;
+- contributor metrics without hidden telemetry; or
+- maintainer/governance proposals.
+
+Start with:
+
+- `.github/workflows/`
+- `.github/scripts/`
+- [`RELEASING.md`](RELEASING.md)
+- [`CHANGELOG.md`](../CHANGELOG.md)
+- [issue #7 — first verified alpha prerelease](https://github.com/moelomda/context-atlas/issues/7)
+
+Release tags and production credentials remain maintainer operations. Pull requests from forks must not require secrets.
+
+## Repository map
+
+| Path | Responsibility | Review sensitivity |
+| --- | --- | --- |
+| `src/core/` | Evidence, Git, storage, temporal knowledge, context packs, privacy, recovery | High; many product invariants live here |
+| `src/web/` | Loopback HTTP API and local dashboard | High for browser security and human mutations |
+| `src/mcp/` | Read-only coding-agent interface | High for capability and output-boundary changes |
+| `src/extensions/` | Trusted in-process extension contracts | High for schema and executable-code boundaries |
+| `src/cli.ts` | Human-operated command surface | Medium to high; preserve exit and confirmation behavior |
+| `tests/` | Behavioral, security, portability, recovery, and package evidence | Every behavior change should update this evidence |
+| `plugin/` | Codex plugin source and generated runtime | Generated artifacts must stay deterministic |
+| `.github/` | CI, security scanning, templates, release automation | High for supply chain and release changes |
+| `docs/` | Architecture, product, risk, release, and contributor guidance | Must distinguish shipped behavior from plans |
+
+## Local verification
+
+Install dependencies once:
+
+```sh
+npm ci
+```
+
+During development, run the smallest relevant test first, then the complete project gate before requesting review:
+
+```sh
+npm run check
+npm audit --audit-level=high
+npm pack --dry-run
+```
+
+Follow any additional checks named in the issue. Changes involving packaging, the generated plugin runtime, migrations, backup/restore, egress, or browser behavior require their specialized checks and manual evidence.
+
+The repository is adding dedicated lint and format gates through [issue #5](https://github.com/moelomda/context-atlas/issues/5). Until that lands, preserve the surrounding style and avoid unrelated formatting churn.
+
+## Pull-request shape
+
+A reviewable pull request normally has:
+
+- one user-visible or engineering outcome;
+- a concise explanation of the previous behavior;
+- automated evidence for the new and failure paths;
+- explicit compatibility, privacy, security, and migration notes;
+- documentation and changelog changes when behavior changes; and
+- no generated, local, secret, or proprietary files.
+
+Prefer separate pull requests for:
+
+- mechanical formatting and behavior;
+- refactoring and feature changes;
+- benchmark infrastructure and performance optimizations;
+- schema migration and unrelated query cleanup; or
+- security hardening and new product surface.
+
+## Trust-boundary checklist
+
+Before requesting review, ask:
+
+- Does any generated or inferred statement gain authority without human review?
+- Can uncertainty, stale state, conflict, truncation, or exclusions disappear at an output boundary?
+- Can repository data leave the machine through a new path?
+- Can a secret-like value enter storage, logs, errors, fixtures, UI, MCP output, or egress?
+- Can an agent perform a new mutation?
+- Can a path escape the intended repository or local state directory?
+- Can a partial write look successful?
+- Can an older database, package, runtime, or client observe incompatible behavior without a versioned error?
+- Is a previously bounded operation now proportional to the whole repository without a disclosed cap?
+
+A “yes” does not automatically make a change unacceptable, but it requires explicit design, tests, documentation, and maintainer review.
+
+## Current public milestone
+
+The active project tracker is [issue #8 — contributor-ready public alpha](https://github.com/moelomda/context-atlas/issues/8). It prioritizes installation, runtime compatibility, contract consistency, contributor onboarding, a verified prerelease, and reproducible performance evidence before broad feature expansion.
+
+Small, well-tested contributions that move that milestone forward are more valuable right now than large speculative rewrites.

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,0 +1,213 @@
+# Context Atlas Quick Start
+
+This guide takes a clean source checkout to the first useful Context Atlas overview, context pack, and local dashboard. It uses a disposable Git repository so no personal or proprietary source is indexed.
+
+> **Alpha status:** Context Atlas has not published its first GitHub release yet. These instructions run the source checkout. Use a current Node.js 24 maintenance release; the exact minimum supported Node.js version is being qualified in [issue #4](https://github.com/moelomda/context-atlas/issues/4).
+
+## 1. Prerequisites
+
+Install:
+
+- Git;
+- Node.js 24 or newer; and
+- npm.
+
+Check the tools:
+
+```sh
+git --version
+node --version
+npm --version
+```
+
+Do not continue with Node.js 22 or older. Context Atlas uses Node's built-in SQLite API.
+
+## 2. Clone and build Context Atlas
+
+The commands in this section work in PowerShell, Bash, zsh, and similar shells.
+
+```sh
+git clone https://github.com/moelomda/context-atlas.git
+cd context-atlas
+npm ci
+npm run build
+node dist/cli.js help
+```
+
+Expected result: the build completes and the final command prints the Context Atlas command list.
+
+Running the complete test gate is recommended before contributing, but it is not required merely to explore the product:
+
+```sh
+npm run check
+```
+
+## 3. Create a disposable project
+
+Keep the demo repository next to the Context Atlas checkout. It contains only synthetic text created by these commands.
+
+### macOS, Linux, Git Bash, or WSL
+
+From the `context-atlas` directory:
+
+```sh
+mkdir -p ../context-atlas-demo
+cd ../context-atlas-demo
+git init
+git config user.name "Context Atlas Demo"
+git config user.email "context-atlas-demo@example.invalid"
+printf '# Demo service\n\nA small synthetic repository for evaluating Context Atlas.\n' > README.md
+printf '{"name":"context-atlas-demo","private":true,"scripts":{"test":"node --test"}}\n' > package.json
+git add README.md package.json
+git commit -m "chore: create synthetic demo repository"
+cd ../context-atlas
+```
+
+### Windows PowerShell
+
+From the `context-atlas` directory:
+
+```powershell
+New-Item -ItemType Directory -Force ..\context-atlas-demo | Out-Null
+git -C ..\context-atlas-demo init
+git -C ..\context-atlas-demo config user.name "Context Atlas Demo"
+git -C ..\context-atlas-demo config user.email "context-atlas-demo@example.invalid"
+Set-Content -LiteralPath ..\context-atlas-demo\README.md -Value "# Demo service`n`nA small synthetic repository for evaluating Context Atlas."
+Set-Content -LiteralPath ..\context-atlas-demo\package.json -Value '{"name":"context-atlas-demo","private":true,"scripts":{"test":"node --test"}}'
+git -C ..\context-atlas-demo add README.md package.json
+git -C ..\context-atlas-demo commit -m "chore: create synthetic demo repository"
+```
+
+Expected result: `context-atlas-demo` contains one commit and no private source or credentials.
+
+## 4. Initialize project memory
+
+### macOS, Linux, Git Bash, or WSL
+
+```sh
+node dist/cli.js init ../context-atlas-demo --name "Context Atlas Demo"
+```
+
+### Windows PowerShell
+
+```powershell
+node dist/cli.js init ..\context-atlas-demo --name "Context Atlas Demo"
+```
+
+Expected result: Context Atlas creates local state under the demo repository's `.context-atlas/` directory and reports the initialized repository.
+
+Context Atlas does not retain full raw diffs or known sensitive files by default. Even so, use only repositories you are authorized to inspect and configure `.atlasignore` before indexing content that needs additional exclusions.
+
+## 5. Inspect the project
+
+### macOS, Linux, Git Bash, or WSL
+
+```sh
+node dist/cli.js overview --repo ../context-atlas-demo
+node dist/cli.js health --repo ../context-atlas-demo
+node dist/cli.js timeline --repo ../context-atlas-demo
+```
+
+### Windows PowerShell
+
+```powershell
+node dist/cli.js overview --repo ..\context-atlas-demo
+node dist/cli.js health --repo ..\context-atlas-demo
+node dist/cli.js timeline --repo ..\context-atlas-demo
+```
+
+Expected result:
+
+- `overview` describes the indexed project without silently treating generated narrative as approved truth;
+- `health` reports repository, database, ledger, freshness, and policy status; and
+- `timeline` shows the synthetic commit history.
+
+The demo is intentionally small, so unknown or empty knowledge areas are expected.
+
+## 6. Generate a bounded context pack
+
+### macOS, Linux, Git Bash, or WSL
+
+```sh
+node dist/cli.js pack "add a health-check endpoint" --json --repo ../context-atlas-demo
+```
+
+### Windows PowerShell
+
+```powershell
+node dist/cli.js pack "add a health-check endpoint" --json --repo ..\context-atlas-demo
+```
+
+Expected result: a bounded JSON context pack containing repository identity, warnings, evidence-linked knowledge, unknowns, and explicit exclusions. The pack is a navigation aid, not proof that a proposed change is correct.
+
+## 7. Open the local dashboard
+
+### macOS, Linux, Git Bash, or WSL
+
+```sh
+node dist/cli.js serve --repo ../context-atlas-demo
+```
+
+### Windows PowerShell
+
+```powershell
+node dist/cli.js serve --repo ..\context-atlas-demo
+```
+
+Open the loopback URL printed by the command, normally `http://127.0.0.1:4242`.
+
+Expected result: the dashboard exposes the overview, project map, timeline, health information, search, and human review workspace. The server deliberately refuses unauthenticated non-loopback binding.
+
+Stop the server with `Ctrl+C`.
+
+## 8. Make a change and synchronize
+
+Add a second synthetic commit in the demo repository, then update Context Atlas.
+
+### macOS, Linux, Git Bash, or WSL
+
+```sh
+printf '\n## Health check\n\nThe service should expose an explicit health endpoint.\n' >> ../context-atlas-demo/README.md
+git -C ../context-atlas-demo add README.md
+git -C ../context-atlas-demo commit -m "docs: describe health endpoint"
+node dist/cli.js sync --repo ../context-atlas-demo
+node dist/cli.js overview --repo ../context-atlas-demo
+```
+
+### Windows PowerShell
+
+```powershell
+Add-Content -LiteralPath ..\context-atlas-demo\README.md -Value "`n## Health check`n`nThe service should expose an explicit health endpoint."
+git -C ..\context-atlas-demo add README.md
+git -C ..\context-atlas-demo commit -m "docs: describe health endpoint"
+node dist/cli.js sync --repo ..\context-atlas-demo
+node dist/cli.js overview --repo ..\context-atlas-demo
+```
+
+Expected result: synchronization records the new repository state and the next overview is bound to the updated snapshot. Human-reviewed guidance can still require a new review when its evidence boundary changes.
+
+## 9. Clean up
+
+Stop any running dashboard before cleanup.
+
+### macOS, Linux, Git Bash, or WSL
+
+```sh
+rm -rf ../context-atlas-demo
+```
+
+### Windows PowerShell
+
+```powershell
+Remove-Item -LiteralPath ..\context-atlas-demo -Recurse -Force
+```
+
+This removes the disposable repository and its local `.context-atlas/` state. It does not modify the Context Atlas source checkout.
+
+## Next steps
+
+- Read the public [`ROADMAP.md`](../ROADMAP.md) for the path from alpha to production readiness.
+- Choose a contribution path in [`CONTRIBUTOR_PATHS.md`](CONTRIBUTOR_PATHS.md).
+- Review [`CONTRIBUTING.md`](../CONTRIBUTING.md) before opening a pull request.
+- Read [`ARCHITECTURE.md`](ARCHITECTURE.md) before changing evidence, authority, time, persistence, MCP, or egress behavior.
+- Report vulnerabilities privately through [`SECURITY.md`](../SECURITY.md), not through a public issue.


### PR DESCRIPTION
## Problem

Context Atlas has deep technical documentation, but a newcomer has to navigate a long README and broad implementation plans before finding a safe first workflow or understanding where a contribution fits.

## Result

This pull request adds:

- a disposable, cross-platform five-minute quick start for Windows, macOS, Linux, Git Bash, and WSL;
- contributor tracks for documentation, accessibility, tests, Git ingestion, storage, context packs, MCP/extensions, security, performance, and release engineering;
- a repository/module map and trust-boundary checklist;
- direct entry links from `CONTRIBUTING.md` and the public roadmap; and
- links to the active contributor-ready alpha tracker and focused starter issues.

## Scope

Documentation only. It does not change ingestion, storage, review, dashboard security, MCP capabilities, egress, schemas, or package behavior.

## Verification

- GitHub compare confirms four documentation files changed and no source or generated files changed.
- Commands were aligned with the existing README and CLI examples.
- The guide uses a synthetic disposable repository and no private source or credentials.
- Full local execution was not possible in the assistant runtime because its container could not resolve `github.com`; hosted repository checks should therefore remain the authoritative gate for this pull request.

## Compatibility, privacy, security, and migration

- Compatibility: no runtime change.
- Privacy: the walkthrough explicitly uses synthetic content and documents cleanup.
- Security: vulnerability reporting remains private through `SECURITY.md`; the guide does not expand any network surface.
- Migration: none.

Progresses #3 and #8.