### PR TITLE
fix: unify external import size limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Release or package has been published.
 ### Changed
 
 - Runtime support is now explicitly Node.js `>=24.12.0 <25`, with an exact-floor CI job, installed-package smoke testing at the floor, and Node 24 type declarations.
+- Dashboard external imports now consume the core/API 256 KiB decoded-source contract, while the HTTP transport ceiling is derived separately for base64 and bounded metadata overhead. Boundary tests cover one byte below, the exact limit, one byte above, and transport overflow.
 - Overview, graph, search, explain, assertion, API, MCP, pack, and dashboard
   presentation paths expose or consume explicit current-use status, settled
   state, reason, authority, evidence, and warnings instead of treating an

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -2,6 +2,7 @@
   "use strict";
 
   const API = Object.freeze({
+    capabilities: "/api/v1",
     overview: "/api/v1/overview",
     map: "/api/v1/graph",
     timeline: "/api/v1/timeline",
@@ -61,7 +62,7 @@
     timeline: { query: "", type: "all", activeIndex: -1 },
     health: { filter: "all" },
     review: { sessionToken: null, sessionPromise: null, proposalId: null, action: null, submitting: false, returnFocus: null },
-    sourceImport: { plan: null, payload: null, submitting: false, returnFocus: null },
+    sourceImport: { plan: null, payload: null, submitting: false, returnFocus: null, maximumSourceBytes: null, capabilitiesPromise: null },
     briefing: { step: 0 },
     searchController: null,
     searchTimer: null,
@@ -103,7 +104,9 @@
     sourceImportFileGroup: document.querySelector("#source-import-file-group"),
     sourceImportTextGroup: document.querySelector("#source-import-text-group"),
     sourceImportFile: document.querySelector("#source-import-file"),
+    sourceImportFileLimit: document.querySelector("#source-import-file-limit"),
     sourceImportText: document.querySelector("#source-import-text"),
+    sourceImportTextLimit: document.querySelector("#source-import-text-limit"),
     sourceImportTitle: document.querySelector("#source-import-title-field"),
     sourceImportOrigin: document.querySelector("#source-import-origin"),
     sourceImportAuthority: document.querySelector("#source-import-authority"),
@@ -385,6 +388,45 @@
     return window.btoa(binary);
   }
 
+  function formatSourceLimit(maximumSourceBytes) {
+    const kibibytes = maximumSourceBytes / 1024;
+    return Number.isInteger(kibibytes)
+      ? `${kibibytes} KiB (${maximumSourceBytes} bytes)`
+      : `${maximumSourceBytes} bytes`;
+  }
+
+  function updateSourceImportLimitCopy(maximumSourceBytes) {
+    const limit = formatSourceLimit(maximumSourceBytes);
+    if (dom.sourceImportFileLimit) {
+      dom.sourceImportFileLimit.textContent = `One .txt or .md file, maximum ${limit}. Its host path is never sent or stored.`;
+    }
+    if (dom.sourceImportTextLimit) {
+      dom.sourceImportTextLimit.textContent = `Paste a bounded summary, not a raw chat archive. Maximum ${limit} after UTF-8 encoding. Remove secrets before preview.`;
+    }
+    dom.sourceImportText.maxLength = maximumSourceBytes;
+  }
+
+  async function ensureSourceImportCapabilities() {
+    if (Number.isSafeInteger(state.sourceImport.maximumSourceBytes) && state.sourceImport.maximumSourceBytes > 0) {
+      return state.sourceImport.maximumSourceBytes;
+    }
+    if (!state.sourceImport.capabilitiesPromise) {
+      state.sourceImport.capabilitiesPromise = fetchJSON(API.capabilities)
+        .then((capabilities) => {
+          const externalImport = asObject(asObject(capabilities).externalImport);
+          const maximumSourceBytes = Number(externalImport.maximumSourceBytes);
+          if (!Number.isSafeInteger(maximumSourceBytes) || maximumSourceBytes < 1) {
+            throw new Error("The local service did not provide a valid external-import source limit.");
+          }
+          state.sourceImport.maximumSourceBytes = maximumSourceBytes;
+          updateSourceImportLimitCopy(maximumSourceBytes);
+          return maximumSourceBytes;
+        })
+        .finally(() => { state.sourceImport.capabilitiesPromise = null; });
+    }
+    return state.sourceImport.capabilitiesPromise;
+  }
+
   function clearSourceImportPreview() {
     state.sourceImport.plan = null;
     state.sourceImport.payload = null;
@@ -427,6 +469,11 @@
     state.sourceImport.returnFocus = document.activeElement;
     dom.sourceImportDialog.showModal();
     window.requestAnimationFrame(() => dom.sourceImportKind.focus());
+    void ensureSourceImportCapabilities().catch((error) => {
+      if (!dom.sourceImportDialog.open) return;
+      dom.sourceImportError.textContent = error instanceof Error ? error.message : "The local source limit could not be loaded.";
+      dom.sourceImportError.hidden = false;
+    });
     announce("Add one external source. Preview is required before import.");
   }
 
@@ -440,6 +487,7 @@
   }
 
   async function sourceImportPayload() {
+    const maximumSourceBytes = await ensureSourceImportCapabilities();
     const mode = dom.sourceImportMode.value;
     let bytes;
     let displayName;
@@ -447,7 +495,7 @@
     if (mode === "browser_file") {
       const file = dom.sourceImportFile.files?.[0];
       if (!file) throw new Error("Choose one UTF-8 text or Markdown file.");
-      if (file.size > 256 * 1024) throw new Error("The selected file exceeds the 256 KiB source limit.");
+      if (file.size > maximumSourceBytes) throw new Error(`The selected file exceeds the ${formatSourceLimit(maximumSourceBytes)} decoded source limit.`);
       bytes = new Uint8Array(await file.arrayBuffer());
       displayName = file.name || "selected-source.txt";
       observedAt = new Date(file.lastModified || Date.now()).toISOString();
@@ -455,7 +503,7 @@
       const text = dom.sourceImportText.value;
       if (!text.trim()) throw new Error("Paste a non-empty conversation summary.");
       bytes = new TextEncoder().encode(text);
-      if (bytes.byteLength > 256 * 1024) throw new Error("The pasted summary exceeds the 256 KiB source limit.");
+      if (bytes.byteLength > maximumSourceBytes) throw new Error(`The pasted summary exceeds the ${formatSourceLimit(maximumSourceBytes)} decoded source limit.`);
       displayName = "pasted-conversation-summary.md";
       observedAt = new Date().toISOString();
     }

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -286,12 +286,12 @@
           </div>
 
           <div id="source-import-file-group">
-            <label class="field-label" for="source-import-file"><span>Selected file</span><small>One .txt or .md file, maximum 256 KiB. Its host path is never sent or stored.</small></label>
+            <label class="field-label" for="source-import-file"><span>Selected file</span><small id="source-import-file-limit">Loading the local decoded source byte limit. Its host path is never sent or stored.</small></label>
             <input class="review-input source-file-input" id="source-import-file" type="file" accept=".txt,.md,text/plain,text/markdown" />
           </div>
           <div id="source-import-text-group" hidden>
-            <label class="field-label" for="source-import-text"><span>Conversation summary</span><small>Paste a bounded summary, not a raw chat archive. Remove secrets before preview.</small></label>
-            <textarea class="review-input" id="source-import-text" rows="7" maxlength="262144" placeholder="Summarize the relevant context, decisions, constraints, and unresolved questions."></textarea>
+            <label class="field-label" for="source-import-text"><span>Conversation summary</span><small id="source-import-text-limit">Loading the local decoded UTF-8 source byte limit. Remove secrets before preview.</small></label>
+            <textarea class="review-input" id="source-import-text" rows="7" placeholder="Summarize the relevant context, decisions, constraints, and unresolved questions."></textarea>
           </div>
 
           <div class="source-import-grid">

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -9,6 +9,7 @@ import {
   applyExternalImportText,
   ExternalImportInputError,
   ExternalImportPlanChangedError,
+  MAX_EXTERNAL_IMPORT_BYTES,
   previewExternalImportText,
   type ExternalImportRequest,
   type ExternalImportTextSource,
@@ -43,8 +44,9 @@ const EXTERNAL_IMPORT_PREVIEW_PATH = "/api/v1/external-import/preview";
 const EXTERNAL_IMPORT_APPLY_PATH = "/api/v1/external-import/apply";
 const SESSION_HEADER = "x-context-atlas-session";
 const MAX_JSON_BODY_BYTES = 4_096;
-const MAX_EXTERNAL_IMPORT_JSON_BODY_BYTES = 300 * 1_024;
-const MAX_BROWSER_SOURCE_BYTES = 192 * 1_024;
+const MAX_EXTERNAL_IMPORT_BASE64_CHARACTERS = Math.ceil(MAX_EXTERNAL_IMPORT_BYTES / 3) * 4;
+const MAX_EXTERNAL_IMPORT_JSON_OVERHEAD_BYTES = 16 * 1_024;
+const MAX_EXTERNAL_IMPORT_JSON_BODY_BYTES = MAX_EXTERNAL_IMPORT_BASE64_CHARACTERS + MAX_EXTERNAL_IMPORT_JSON_OVERHEAD_BYTES;
 const MAX_REVIEW_RATIONALE_CHARACTERS = 1_000;
 const MIN_REVIEW_RATIONALE_CHARACTERS = 8;
 
@@ -210,7 +212,7 @@ function handleVersionedApi(repoRoot: string, url: URL, request: IncomingMessage
           surface: "loopback-browser-only",
           preview: EXTERNAL_IMPORT_PREVIEW_PATH,
           apply: EXTERNAL_IMPORT_APPLY_PATH,
-          maximumSourceBytes: MAX_BROWSER_SOURCE_BYTES,
+          maximumSourceBytes: MAX_EXTERNAL_IMPORT_BYTES,
           statelessPreview: true,
           requiresExactConfirmation: "IMPORT",
           agentSurfaceReadOnly: true,
@@ -370,7 +372,10 @@ async function handleVersionedPost(
     const bodyError = error instanceof RequestBodyError
       ? error
       : new RequestBodyError(400, "invalid_json", "The request body must be valid JSON.");
-    sendVersionedError(repoRoot, response, bodyError.status, bodyError.code, bodyError.message);
+    const message = isExternalImportPath(url.pathname) && bodyError.code === "payload_too_large"
+      ? `The external-import JSON transport body must not exceed ${MAX_EXTERNAL_IMPORT_JSON_BODY_BYTES} bytes; the decoded source limit is ${MAX_EXTERNAL_IMPORT_BYTES} bytes.`
+      : bodyError.message;
+    sendVersionedError(repoRoot, response, bodyError.status, bodyError.code, message);
     return;
   }
 
@@ -624,8 +629,8 @@ function validateExternalImportPost(
     return { error: "invalid_external_source_encoding", message: "The selected source bytes must use canonical base64 encoding." };
   }
   const bytes = Buffer.from(bodyBase64, "base64");
-  if (bytes.byteLength > MAX_BROWSER_SOURCE_BYTES) {
-    return { error: "external_source_too_large", message: `The selected browser source must not exceed ${MAX_BROWSER_SOURCE_BYTES} bytes.` };
+  if (bytes.byteLength > MAX_EXTERNAL_IMPORT_BYTES) {
+    return { error: "external_source_too_large", message: `The selected browser source exceeds the decoded ${MAX_EXTERNAL_IMPORT_BYTES}-byte source limit.` };
   }
   if (applying && (typeof object.planId !== "string" || typeof object.confirmation !== "string")) {
     return { error: "invalid_external_import_confirmation", message: "Apply requires a preview planId and exact IMPORT confirmation." };
@@ -661,7 +666,7 @@ function hasExactFields(value: Record<string, unknown>, expected: readonly strin
 }
 
 function isCanonicalBase64(value: string): boolean {
-  if (!value || value.length > MAX_EXTERNAL_IMPORT_JSON_BODY_BYTES || value.length % 4 !== 0
+  if (!value || value.length > MAX_EXTERNAL_IMPORT_BASE64_CHARACTERS || value.length % 4 !== 0
     || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) return false;
   return Buffer.from(value, "base64").toString("base64") === value;
 }

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterEach, test } from "node:test";
 import { Script } from "node:vm";
 import { AtlasDatabase } from "../src/core/database.js";
+import { MAX_EXTERNAL_IMPORT_BYTES } from "../src/core/external-import.js";
 import { approveProposal, createProposal, listProposals } from "../src/core/proposals.js";
 import { startWebServer } from "../src/web/server.js";
 import { createFixtureRepository, initializeFixture, removeFixture } from "./helpers.js";
@@ -57,6 +58,8 @@ test("dashboard source keeps the launch interaction and accessibility contract",
   assert.match(html, /id="source-import-dialog"/);
   assert.match(html, /id="source-import-form"[^>]*novalidate/);
   assert.match(html, /id="source-import-file"[^>]*type="file"/);
+  assert.match(html, /id="source-import-file-limit"/);
+  assert.match(html, /id="source-import-text-limit"/);
   assert.match(html, /id="source-import-error"[^>]*role="alert"/);
   assert.match(html, /id="source-import-confirmation"/);
   assert.match(html, /aria-describedby="briefing-description"/);
@@ -111,9 +114,13 @@ test("dashboard source keeps the launch interaction and accessibility contract",
   assert.match(script, /async function submitProposalReview/);
   assert.match(script, /async function previewSourceImport/);
   assert.match(script, /async function submitSourceImport/);
+  assert.match(script, /capabilities: "\/api\/v1"/);
   assert.match(script, /externalImportPreview: "\/api\/v1\/external-import\/preview"/);
   assert.match(script, /externalImportApply: "\/api\/v1\/external-import\/apply"/);
+  assert.match(script, /async function ensureSourceImportCapabilities/);
+  assert.match(script, /maximumSourceBytes/);
   assert.match(script, /bodyBase64: bytesToBase64\(bytes\)/);
+  assert.doesNotMatch(`${html}\n${script}`, /256\s*\*\s*1024|maximum 256 KiB/, "the browser must consume the versioned API limit instead of duplicating it");
   assert.match(script, /dom\.sourceImportConfirmation\.value !== "IMPORT"/);
   assert.match(script, /function renderReview/);
   assert.match(script, /Evidence changed since proposal creation/);
@@ -151,7 +158,10 @@ test("dashboard source keeps the launch interaction and accessibility contract",
   assert.match(serverSource, /timingSafeEqual/);
   assert.match(serverSource, /validateSameOriginRequest/);
   assert.match(serverSource, /MAX_JSON_BODY_BYTES = 4_096/);
+  assert.match(serverSource, /MAX_EXTERNAL_IMPORT_BASE64_CHARACTERS/);
   assert.match(serverSource, /MAX_EXTERNAL_IMPORT_JSON_BODY_BYTES/);
+  assert.match(serverSource, /maximumSourceBytes: MAX_EXTERNAL_IMPORT_BYTES/);
+  assert.doesNotMatch(serverSource, /MAX_BROWSER_SOURCE_BYTES/);
   assert.match(serverSource, /findSecrets\(rationale\)/);
   assert.match(serverSource, /const urlHost = host\.includes\(":"\) \? `\[\$\{host\}\]` : host/);
   assert.doesNotMatch(serverSource, /console\.(?:log|info|warn|error)/, "the review session token must never enter server logs");
@@ -365,13 +375,20 @@ test("local dashboard serves protected static assets and API data", async () => 
 
     const capabilitiesResponse = await fetch(`${url}/api/v1`);
     const capabilitiesBody = await capabilitiesResponse.json() as {
-      data: { readOnly: boolean; agentSurfaceReadOnly: boolean; humanReviewMutations: boolean; humanReview: { surface: string; agentSurfaceReadOnly: boolean } };
+      data: {
+        readOnly: boolean;
+        agentSurfaceReadOnly: boolean;
+        humanReviewMutations: boolean;
+        humanReview: { surface: string; agentSurfaceReadOnly: boolean };
+        externalImport: { maximumSourceBytes: number };
+      };
     };
     assert.equal(capabilitiesBody.data.readOnly, false);
     assert.equal(capabilitiesBody.data.agentSurfaceReadOnly, true);
     assert.equal(capabilitiesBody.data.humanReviewMutations, true);
     assert.equal(capabilitiesBody.data.humanReview.surface, "loopback-browser-only");
     assert.equal(capabilitiesBody.data.humanReview.agentSurfaceReadOnly, true);
+    assert.equal(capabilitiesBody.data.externalImport.maximumSourceBytes, MAX_EXTERNAL_IMPORT_BYTES);
 
     const graphResponse = await fetch(`${url}/api/v1/graph`);
     assert.equal(graphResponse.status, 200);
@@ -538,6 +555,36 @@ test("browser external import requires preview, same-origin session proof, and e
     assert.equal(bootstrap.status, 200);
     const bootstrapBody = await bootstrap.json() as { data: { token: string } };
     const token = bootstrapBody.data.token;
+
+    const boundaryPayload = (byteLength: number) => ({
+      ...payload,
+      source: {
+        ...payload.source,
+        bodyBase64: Buffer.alloc(byteLength, 0x61).toString("base64"),
+        displayName: `boundary-${byteLength}.txt`,
+      },
+      metadata: { ...payload.metadata },
+    });
+    for (const byteLength of [MAX_EXTERNAL_IMPORT_BYTES - 1, MAX_EXTERNAL_IMPORT_BYTES]) {
+      const boundaryPreview = await post(`${url}/api/v1/external-import/preview`, boundaryPayload(byteLength), token);
+      const boundaryBody = await boundaryPreview.text();
+      assert.equal(boundaryPreview.status, 200, `${byteLength} decoded bytes must fit the advertised source contract: ${boundaryBody}`);
+      assert.equal(countImports(), 0, "boundary previews must remain zero-write");
+    }
+    const aboveLimit = await post(`${url}/api/v1/external-import/preview`, boundaryPayload(MAX_EXTERNAL_IMPORT_BYTES + 1), token);
+    assert.equal(aboveLimit.status, 422);
+    const aboveLimitBody = await aboveLimit.json() as { data: { code: string; message: string } };
+    assert.equal(aboveLimitBody.data.code, "external_source_too_large");
+    assert.match(aboveLimitBody.data.message, new RegExp(`decoded ${MAX_EXTERNAL_IMPORT_BYTES}-byte source limit`));
+
+    const transportPayload = boundaryPayload(MAX_EXTERNAL_IMPORT_BYTES);
+    transportPayload.metadata.purpose = "x".repeat(20_000);
+    const transportLimit = await post(`${url}/api/v1/external-import/preview`, transportPayload, token);
+    assert.equal(transportLimit.status, 413);
+    const transportLimitBody = await transportLimit.json() as { data: { code: string; message: string } };
+    assert.equal(transportLimitBody.data.code, "payload_too_large");
+    assert.match(transportLimitBody.data.message, /JSON transport body/);
+    assert.match(transportLimitBody.data.message, new RegExp(`decoded source limit is ${MAX_EXTERNAL_IMPORT_BYTES} bytes`));
 
     const noSessionPreview = await post(`${url}/api/v1/external-import/preview`, payload);
     assert.equal(noSessionPreview.status, 403);


### PR DESCRIPTION
## Problem

The external-source import workflow exposed conflicting contracts:

- the core importer and dashboard stated a 256 KiB decoded-source limit;
- the HTTP server accepted only 192 KiB of decoded source; and
- the 300 KiB JSON transport ceiling could not reliably carry a 256 KiB source after base64 encoding.

A user could therefore select a source that the browser described as valid and then receive a server rejection.

## Result

This pull request:

- uses the core `MAX_EXTERNAL_IMPORT_BYTES` constant as the decoded-source contract in the HTTP API;
- derives the JSON transport ceiling separately from exact base64 expansion plus bounded metadata overhead;
- advertises the decoded limit through the versioned `/api/v1` capabilities response;
- makes the dashboard consume that capability instead of duplicating a hardcoded value;
- explains decoded-source and JSON-transport failures separately;
- keeps preview zero-write and all existing consent, origin, session, secret-scanning, and authority checks intact; and
- updates the changelog.

## Boundary evidence

The web contract test now proves:

- one byte below the decoded limit is accepted;
- the exact decoded limit is accepted;
- one byte above the decoded limit is rejected as `external_source_too_large`;
- transport overflow is rejected as `payload_too_large` with a distinct explanation;
- boundary previews do not create imports; and
- the original normal preview/apply/idempotency flow still succeeds afterward.

## Verification

A one-shot hosted verification branch applied this exact five-file tree and completed `npm run check` successfully on Node.js 24.12.0. The result was then consolidated onto this clean one-commit branch. No temporary workflow, patch script, diagnostic file, generated local state, or unrelated source change is present.

The protected pull-request CI, exact-floor job, Windows/macOS/Linux matrix, coverage, package/install smoke test, CodeQL, and dependency review remain the merge gate. Local execution is not claimed because the assistant runtime could not resolve `github.com`.

## Compatibility, privacy, security, and migration

- **Compatibility:** the versioned API now reports the same decoded limit enforced by the core importer.
- **Privacy/security:** no new egress or network surface; source bytes remain loopback-only, same-origin, session-gated, bounded, UTF-8 validated, and secret-scanned.
- **Migration:** no database or stored-data migration.

Closes #2
Progresses #7 and #8.