### PR TITLE
docs(readme): make npm commands portable across shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ breaking changes. Those changes must be called out explicitly.
 
 ## [Unreleased]
 
+### Changed
+
+- Updated README documentation to use cross-platform `npm` commands instead of Windows-specific `npm.cmd` in generic sections
+
 Reserved for changes after `0.1.0` is tagged or published. Version `0.1.0`
 below remains an **unreleased release candidate**; its dated heading is the
 candidate identity used by release validation, not evidence that a GitHub

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Requirements: Git and Node.js `>=24.12.0 <25`. See [`docs/RUNTIME_SUPPORT.md`](d
 ```powershell
 git clone https://github.com/moelomda/context-atlas.git
 cd context-atlas
-npm.cmd ci
-npm.cmd run build
+npm ci
+npm run build
 node dist/cli.js init C:\path\to\your\git-repository --name "My Project"
 node dist/cli.js serve --repo C:\path\to\your\git-repository
 ```
@@ -153,9 +153,9 @@ Run `node dist/cli.js help` for the complete command list. The main workflows ar
 
 ## Development and verification
 
-```powershell
-npm.cmd run build
-npm.cmd test
+```sh
+npm run build
+npm test
 ```
 
 The current local worktree has passed the normal behavioral suite (**122/122 tests in 693,394 ms**) and the coverage run (**122/122 tests in 901,735 ms; 95.40% lines, 96.07% functions, and 76.81% branches**). Strict source/test TypeScript compilation, JavaScript syntax, JSON/YAML parsing, release-identity validation, and an online `npm audit` with zero reported vulnerabilities also passed. These are local Windows results, not cross-platform or hosted results.


### PR DESCRIPTION
## Problem

The README uses Windows-specific `npm.cmd` in generic sections, which fails on macOS/Linux shells. macOS and Linux users typically invoke `npm` directly.

## Solution

- Replaced `npm.cmd` with `npm` in lines 44-45 (Quick start) and 157-158 (Development and verification)
- Changed the Development block from `powershell` to `sh` for cross-platform clarity
- Added entry under `[Unreleased]` in `CHANGELOG.md`

## User-visible result

The README commands now work across PowerShell, Bash, zsh, and other POSIX shells. The pattern matches the existing `docs/QUICK_START.md` which already separates POSIX and PowerShell workflows.

## Verification

- Commands match `docs/QUICK_START.md` patterns
- Aligns with `CONTRIBUTING.md` lines 46-48 which already use `npm`
- No code changes, documentation only
- Manually inspected all 4 instances of `npm.cmd` in README.md
- No behavior changes, only command portability

Fixes #14